### PR TITLE
When pushing, delete branch in origin as well

### DIFF
--- a/GitFlowExtensions/git-flow-hotfix
+++ b/GitFlowExtensions/git-flow-hotfix
@@ -346,7 +346,7 @@ cmd_finish() {
 	fi
 	if flag push; then
 		echo "- '$DEVELOP_BRANCH', '$MASTER_BRANCH' and tags have been pushed to '$ORIGIN'"
-		echo "- Release branch '$BRANCH' in '$ORIGIN' has been deleted."
+		echo "- Hotfix branch '$BRANCH' in '$ORIGIN' has been deleted."
 	fi
 	echo
 }


### PR DESCRIPTION
When finishing a release while specifying the -p flag, the release branch is removed on origin.  For hotfix, it did not, so this change makes behavior consistent between both functions.

See https://github.com/jhoerr/posh-gitflow/blob/master/GitFlowExtensions/git-flow-release#L287-L315 for reference for how this works in the release workflow.
