### PR TITLE
Clarify instructions

### DIFF
--- a/Configure-GitFlow.ps1
+++ b/Configure-GitFlow.ps1
@@ -34,7 +34,7 @@ Function Configure-GitFlow
 		Copy-Item (Join-Path $gitPath "libiconv-2.dll") -Destination (Join-Path $gitPath "libiconv2.dll") -Verbose
 	}
 
-	Write-Host "Press Any Key to finish"
+	Write-Host "Press Enter to finish"
 	Read-Host
 }
 


### PR DESCRIPTION
Configuration script prompts the user to enter any key to finish, but in reality requires Enter.