### PR TITLE
Ability to install withut Github desktop app installed

### DIFF
--- a/xaa
+++ b/xaa
@@ -1,0 +1,6 @@
+
+Name                           Value                                                                                                                                                                                                                                                                                                   
+----                           -----                                                                                                                                                                                                                                                                                                   
+Path                           C:\Program Files\ConEmu;C:\Program Files\ConEmu\ConEmu;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\Program Files\Microsoft DNX\Dnvm\;C:\Program Files\Microsoft SQL Server\120\Tools\Binn\;C:\Program Files (x86)\Windows Kits\10\Windows ...
+
+

--- a/xaa
+++ b/xaa
@@ -1,6 +1,0 @@
-
-Name                           Value                                                                                                                                                                                                                                                                                                   
-----                           -----                                                                                                                                                                                                                                                                                                   
-Path                           C:\Program Files\ConEmu;C:\Program Files\ConEmu\ConEmu;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\Program Files\Microsoft DNX\Dnvm\;C:\Program Files\Microsoft SQL Server\120\Tools\Binn\;C:\Program Files (x86)\Windows Kits\10\Windows ...
-
-


### PR DESCRIPTION
As talked in #8 it has been difficult to make posh-gitflow work without GitHub desktop installed. 
This pull request adds support for installing without GitHub desktop, allowing to be use with official installations of git for windows.

The flow first searches for known git environment variables, if not found tries to look for a Github desktop installation as before. It allows the user to override the search logic, by passing the git installation path as paremeter.